### PR TITLE
アンケート回答者の一括取得api

### DIFF
--- a/backend/repository/answer.go
+++ b/backend/repository/answer.go
@@ -38,3 +38,16 @@ func (r *Repository) UpdateAnswer(answer *model.Answer) error {
 
 	return nil
 }
+
+func (r *Repository) GetAnswersByID(id uint) ([]model.Answer, error) {
+	var answers []model.Answer
+
+	if err := r.db.
+		Where("question_id = ?", id).
+		Find(&answers).
+		Error; err != nil {
+		return nil, err
+	}
+
+	return answers, nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -1317,7 +1317,10 @@ export interface operations {
     getQuestionAnswers: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description ログインしているユーザーのtraQ ID（NeoShowcaseが自動で付与） */
+                "X-Forwarded-User"?: components["parameters"]["X-Forwarded-User"];
+            };
             path: {
                 /** @description 質問ID */
                 question_id: components["parameters"]["QuestionId"];

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -270,6 +270,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/users/answers/{question_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** 質問に対するユーザーの回答一覧を取得 */
+        get: operations["getQuestionAnswers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/users/{traq_id}/answers/{question_id}": {
         parameters: {
             query?: never;
@@ -474,6 +491,10 @@ export interface components {
             question_id: number;
             user_traq_id: string;
             content?: (string | string[]) | null;
+        };
+        GetQuestionAnswers: {
+            question_id?: number;
+            answers?: unknown[];
         };
         PutAnswerRequest: {
             content?: (string | string[]) | null;
@@ -1290,6 +1311,30 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    getQuestionAnswers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description 質問ID */
+                question_id: components["parameters"]["QuestionId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetQuestionAnswers"][];
+                };
+            };
             500: components["responses"]["InternalServerError"];
         };
     };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -595,6 +595,7 @@ paths:
         - Questions
       operationId: getQuestionAnswers
       parameters:
+        - $ref: "#/components/parameters/X-Forwarded-User"
         - $ref: "#/components/parameters/QuestionId"
       responses:
         "200":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -588,6 +588,25 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /api/users/answers/{question_id}:
+    get:
+      summary: 質問に対するユーザーの回答一覧を取得
+      tags:
+        - Questions
+      operationId: getQuestionAnswers
+      parameters:
+        - $ref: "#/components/parameters/QuestionId"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GetQuestionAnswers"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /api/users/{traq_id}/answers/{question_id}:
     get:
       summary: ユーザーの回答を取得
@@ -1225,6 +1244,16 @@ components:
         - id
         - question_id
         - user_traq_id
+    GetQuestionAnswers:
+      type: object
+      properties:
+        question_id:
+          type: integer
+        answers:
+          type: array
+          items:
+            user_traq_id:
+              type: string
     PutAnswerRequest:
       type: object
       properties:


### PR DESCRIPTION
一括取得できるapiを作成しました。
子質問に対してリクエストをします。子質問のidと回答したユーザーのtraqidの配列を返します。

公開質問でない場合は合宿係じゃないとforbiddenを返しています。