### PR TITLE
選択肢の更新削除用のapi

### DIFF
--- a/backend/repository/option.go
+++ b/backend/repository/option.go
@@ -29,3 +29,21 @@ func (r *Repository) GetOptions(query *GetOptionsQuery) ([]model.Option, error) 
 
 	return options, nil
 }
+
+func (r *Repository) UpdateOption(ID uint, option *model.Option) error {
+
+	if err := r.db.Where("id = ?", ID).Updates(option).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Repository) DeleteOption(ID uint) error {
+
+	if err := r.db.Delete(&model.Option{}, ID).Error; err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -247,7 +247,8 @@ export interface paths {
         /** 選択肢を更新 */
         put: operations["putOption"];
         post?: never;
-        delete?: never;
+        /** 選択肢を削除 */
+        delete: operations["deleteOption"];
         options?: never;
         head?: never;
         patch?: never;
@@ -1249,6 +1250,28 @@ export interface operations {
                     "application/json": components["schemas"]["Option"];
                 };
             };
+            400: components["responses"]["BadRequest"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    deleteOption: {
+        parameters: {
+            query?: never;
+            header?: {
+                /** @description ログインしているユーザーのtraQ ID（NeoShowcaseが自動で付与） */
+                "X-Forwarded-User"?: components["parameters"]["X-Forwarded-User"];
+            };
+            path: {
+                /** @description 選択肢ID */
+                option_id: components["parameters"]["OptionId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            204: components["responses"]["NoContent"];
             400: components["responses"]["BadRequest"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -560,6 +560,25 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
+    delete:
+      summary: 選択肢を削除
+      tags:
+        - Questions
+      operationId: deleteOption
+      parameters:
+        - $ref: "#/components/parameters/OptionId"
+        - $ref: "#/components/parameters/X-Forwarded-User"
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /api/me/answers/{question_id}:
     get:
       summary: 自分の回答を取得


### PR DESCRIPTION
更新なんですが、選択肢のidと選択肢をもつ質問のidをどちらも取得しています。
片方だけでも動きはするなと思いました。

アンケートの編集の際に必要だったので作成しました